### PR TITLE
Feat: 認証機構をバックエンド側と連携できるようにする。

### DIFF
--- a/src/atoms/auth/loginUser.ts
+++ b/src/atoms/auth/loginUser.ts
@@ -7,7 +7,7 @@ export interface UserState {
   nickname: string;
   uid: string;
   twitter_name: string;
-  visibility: "private" | "public";
+  visibility: string;
 }
 
 export const loginUserAtom = atom<UserState>({
@@ -17,5 +17,5 @@ export const loginUserAtom = atom<UserState>({
   nickname: "",
   uid: "",
   twitter_name: "",
-  visibility: "private",
+  visibility: "",
 });

--- a/src/lib/auth/firebaseAuth.ts
+++ b/src/lib/auth/firebaseAuth.ts
@@ -24,18 +24,18 @@ export const useFirebaseAuth = () => {
         avatar: authUser.photoURL || "",
         uid: authUser.uid,
         introduction: "",
-        twitter_name: "", // 新しいプロパティを初期化
-        visibility: "private", // 新しいプロパティを初期化
+        twitter_name: "",
+        visibility: "",
         authChecked: true,
       });
     } else {
       setUserState({
-        avatar: "",
         nickname: "",
+        avatar: "",
         uid: "",
         introduction: "",
-        twitter_name: "", // 新しいプロパティを初期化
-        visibility: "private", // 新しいプロパティを初期化
+        twitter_name: "",
+        visibility: "",
         authChecked: false,
       });
     }
@@ -57,7 +57,7 @@ export const useFirebaseAuth = () => {
       .then((result) => {
         setOpened(false);
         if (getAdditionalUserInfo(result)?.isNewUser) {
-          navigate("/onboarding");
+          navigate("/");
           return;
         }
         navigate("/");
@@ -83,7 +83,7 @@ export const useFirebaseAuth = () => {
       uid: "",
       introduction: "",
       twitter_name: "", // 新しいプロパティを初期化
-      visibility: "private", // 新しいプロパティを初期化
+      visibility: "", // 新しいプロパティを初期化
       authChecked: false,
     });
   };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -11,5 +11,5 @@ authStore.set(loginUserAtom, {
   nickname: "",
   uid: "",
   twitter_name: "", // 新しいプロパティを初期化
-  visibility: "private",
+  visibility: "",
 });


### PR DESCRIPTION
# issue
Close #35 

# 概要
- Googleログイン時に、トークンをバックエンド側に送信して検証を行うようにする
- 取得する際のvisibilityの値を空白にする。

バックエンド側でユーザーに紐づく情報を管理できるようにするため
ログイン時には特に必要のない値なので、usersのvisibilityの初期値"private"はrails側で作ることにした。ログイン時には特に必要のない値なので