### PR TITLE
feat: ログアウト時のページ遷移と、非ログインユーザーはTopページ以外に遷移しようとした時リダイレクトするように

### DIFF
--- a/src/components/HeaderAction.tsx
+++ b/src/components/HeaderAction.tsx
@@ -178,6 +178,7 @@ const HeaderAction = ({ isLogin }: HeaderActionProps) => {
                   onClick={() => {
                     const auth = getAuth();
                     auth.signOut();
+                    navigate("/");
                   }}
                 >
                   ログアウト

--- a/src/features/auth/api/postIdToken.ts
+++ b/src/features/auth/api/postIdToken.ts
@@ -10,6 +10,7 @@ export const postIdToken = async (config: {
   axios.interceptors.response.use(
     (response) => response,
     (error) => {
+      console.error(error);
       throw new Error("login error");
     }
   );

--- a/src/routes/RouteAuthGuard.tsx
+++ b/src/routes/RouteAuthGuard.tsx
@@ -13,9 +13,9 @@ export const RouteAuthGuard = ({
   redirect,
 }: RouteAuthGuardProps) => {
   const location = useLocation();
-  const { currentUser, authChecked } = useFirebaseAuth();
+  const { currentUser } = useFirebaseAuth();
 
-  if (authChecked) {
+  if (currentUser.authChecked) {
     if (currentUser.uid) {
       return <>{component}</>;
     } else {
@@ -24,6 +24,9 @@ export const RouteAuthGuard = ({
       );
     }
   } else {
+    if (location.pathname !== "/") {
+      return <Navigate to="/" replace={true} />;
+    }
     return (
       <Center>
         <Loader />


### PR DESCRIPTION
# 概要
ページ遷移の問題の解決。
リントチェックの回避のため、一時的にconsole.errorを設置