### PR TITLE
Feat: 選択したgenreとplatformでゲームカードの絞り込みができるようにする。

### DIFF
--- a/src/features/management/atoms/index.ts
+++ b/src/features/management/atoms/index.ts
@@ -3,3 +3,6 @@ import { atom } from "jotai";
 export const myGamesToShowAtom = atom<number>(14);
 
 export const sortOrderAtom = atom<"ascending" | "descending" | null>(null);
+
+export const selectedGenresAtom = atom<string[]>([]);
+export const selectedPlatformsAtom = atom<string[]>([]);

--- a/src/features/management/components/GameStatusSelecter.tsx
+++ b/src/features/management/components/GameStatusSelecter.tsx
@@ -5,7 +5,12 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import None from "../../../assets/None.png";
-import { myGamesToShowAtom, sortOrderAtom } from "../atoms";
+import {
+  myGamesToShowAtom,
+  selectedGenresAtom,
+  selectedPlatformsAtom,
+  sortOrderAtom,
+} from "../atoms";
 import { GameCard, GameListsType } from "../types";
 import { sortGamesByRating } from "../utils";
 import MyGame from "./MyGame";
@@ -21,18 +26,34 @@ const GameStatusSelecter = ({
   const largerThanSm = useMediaQuery("sm");
   const sortOrder = useAtomValue(sortOrderAtom);
   const [sortedGameItems, setSortedGameItems] = useState<GameCard[]>([]);
+  const selectedGenres = useAtomValue(selectedGenresAtom);
+  const selectedPlatforms = useAtomValue(selectedPlatformsAtom);
 
   useEffect(() => {
-    if (sortOrder === "descending") {
-      const sortedGames = sortGamesByRating(gameItems, false);
-      setSortedGameItems(sortedGames);
-    } else if (sortOrder === "ascending") {
-      const sortedGames = sortGamesByRating(gameItems, true);
-      setSortedGameItems(sortedGames);
-    } else {
-      setSortedGameItems(gameItems);
+    let filteredGames = gameItems;
+
+    if (selectedGenres.length) {
+      filteredGames = filteredGames.filter((game) =>
+        game.genres?.some((genre) => selectedGenres.includes(genre.name))
+      );
     }
-  }, [sortOrder, gameItems]);
+
+    if (selectedPlatforms.length) {
+      filteredGames = filteredGames.filter((game) =>
+        game.platforms?.some((platform) =>
+          selectedPlatforms.includes(platform.name)
+        )
+      );
+    }
+
+    if (sortOrder === "descending") {
+      filteredGames = sortGamesByRating(filteredGames, false);
+    } else if (sortOrder === "ascending") {
+      filteredGames = sortGamesByRating(filteredGames, true);
+    }
+
+    setSortedGameItems(filteredGames);
+  }, [sortOrder, gameItems, selectedGenres, selectedPlatforms]);
 
   return (
     <>
@@ -86,7 +107,7 @@ const GameStatusSelecter = ({
         </>
       ) : (
         <div className="my-10 flex justify-center">
-          <Image src={None} alt="No games available" />
+          <Image src={None} alt="No games available" width={300} />
         </div>
       )}
     </>

--- a/src/features/management/components/GameStatusSelecter.tsx
+++ b/src/features/management/components/GameStatusSelecter.tsx
@@ -88,7 +88,7 @@ const GameStatusSelecter = ({
             </div>
           ))}
         </div>
-      ) : gameItems.length > 0 ? (
+      ) : sortedGameItems.length > 0 ? (
         <>
           <SimpleGrid cols={largerThanSm ? 2 : 1}>
             {sortedGameItems.slice(0, myGamesToShow).map((gameItem) => (

--- a/src/features/management/components/RefineModal.tsx
+++ b/src/features/management/components/RefineModal.tsx
@@ -1,19 +1,23 @@
 import { Button, Divider, Modal, Text } from "@mantine/core";
 import { FC } from "react";
 
+import { GameCard } from "../types";
+import { extractUniqueGenresAndPlatforms } from "../utils";
+
 type RefineModalProps = {
   opened: boolean;
   onClose: () => void;
+  gameItems: GameCard[];
 };
 
-const RefineModal: FC<RefineModalProps> = ({ opened, onClose }) => {
-  const buttonsArray = new Array(30).fill(null);
+const RefineModal: FC<RefineModalProps> = ({ opened, onClose, gameItems }) => {
+  const { genres, platforms } = extractUniqueGenresAndPlatforms(gameItems);
 
   return (
     <Modal opened={opened} onClose={onClose} size="sm">
       <Text>ジャンルで絞る</Text>
       <Divider my="sm" />
-      {buttonsArray.map((_, index) => (
+      {genres.map((genre, index) => (
         <Button
           key={`genres-${index}`}
           radius="lg"
@@ -22,13 +26,13 @@ const RefineModal: FC<RefineModalProps> = ({ opened, onClose }) => {
           className="mr-1"
           variant="outline"
         >
-          genres
+          {genre}
         </Button>
       ))}
       <Divider my="sm" />
       <Text>プラットフォームで絞る</Text>
       <Divider my="sm" />
-      {buttonsArray.map((_, index) => (
+      {platforms.map((platform, index) => (
         <Button
           key={`platform-${index}`}
           radius="lg"
@@ -37,7 +41,7 @@ const RefineModal: FC<RefineModalProps> = ({ opened, onClose }) => {
           className="mr-1"
           variant="outline"
         >
-          platform
+          {platform}
         </Button>
       ))}
     </Modal>

--- a/src/features/management/components/RefineModal.tsx
+++ b/src/features/management/components/RefineModal.tsx
@@ -1,6 +1,8 @@
-import { Button, Divider, Modal, Text } from "@mantine/core";
+import { Button, Divider, Modal, Title } from "@mantine/core";
+import { useAtom } from "jotai";
 import { FC } from "react";
 
+import { selectedGenresAtom, selectedPlatformsAtom } from "../atoms";
 import { GameCard } from "../types";
 import { extractUniqueGenresAndPlatforms } from "../utils";
 
@@ -12,10 +14,28 @@ type RefineModalProps = {
 
 const RefineModal: FC<RefineModalProps> = ({ opened, onClose, gameItems }) => {
   const { genres, platforms } = extractUniqueGenresAndPlatforms(gameItems);
+  const [selectedGenres, setSelectedGenres] = useAtom(selectedGenresAtom);
+  const [selectedPlatforms, setSelectedPlatforms] = useAtom(
+    selectedPlatformsAtom
+  );
+
+  const handleGenreClick = (genre: string) => {
+    setSelectedGenres((prev) =>
+      prev.includes(genre) ? prev.filter((g) => g !== genre) : [...prev, genre]
+    );
+  };
+
+  const handlePlatformClick = (platform: string) => {
+    setSelectedPlatforms((prev) =>
+      prev.includes(platform)
+        ? prev.filter((p) => p !== platform)
+        : [...prev, platform]
+    );
+  };
 
   return (
     <Modal opened={opened} onClose={onClose} size="sm">
-      <Text>ジャンルで絞る</Text>
+      <Title order={5}>ゲームジャンルで絞る</Title>
       <Divider my="sm" />
       {genres.map((genre, index) => (
         <Button
@@ -24,13 +44,15 @@ const RefineModal: FC<RefineModalProps> = ({ opened, onClose, gameItems }) => {
           size="xs"
           compact
           className="mr-1"
-          variant="outline"
+          variant={selectedGenres.includes(genre) ? "filled" : "outline"}
+          onClick={() => handleGenreClick(genre)}
         >
           {genre}
         </Button>
       ))}
-      <Divider my="sm" />
-      <Text>プラットフォームで絞る</Text>
+      <Title order={5} className="mt-5">
+        ゲーム機体で絞る
+      </Title>
       <Divider my="sm" />
       {platforms.map((platform, index) => (
         <Button
@@ -39,7 +61,8 @@ const RefineModal: FC<RefineModalProps> = ({ opened, onClose, gameItems }) => {
           size="xs"
           compact
           className="mr-1"
-          variant="outline"
+          variant={selectedPlatforms.includes(platform) ? "filled" : "outline"}
+          onClick={() => handlePlatformClick(platform)}
         >
           {platform}
         </Button>

--- a/src/features/management/container/GameManagement.tsx
+++ b/src/features/management/container/GameManagement.tsx
@@ -42,7 +42,7 @@ const GameManagement = () => {
       />
       <Container>
         <Profile />
-        <GameManagementControls />
+        <GameManagementControls gameItems={userGamesQuery.data || []} />
         <GameStatusSelecter
           game_status={[
             {

--- a/src/features/management/container/GameManagementControls.tsx
+++ b/src/features/management/container/GameManagementControls.tsx
@@ -5,8 +5,9 @@ import { useNavigate } from "react-router-dom";
 
 import { sortOrderAtom } from "../atoms/index";
 import RefineModal from "../components/RefineModal";
+import { AllGame } from "../types";
 
-const GameManagementControls = () => {
+const GameManagementControls = ({ gameItems }: AllGame) => {
   const navigate = useNavigate();
   const [opened, { open, close }] = useDisclosure(false);
   const [, setSortOrder] = useAtom(sortOrderAtom);
@@ -54,7 +55,7 @@ const GameManagementControls = () => {
           >
             評価が低い順に並べる
           </Button>
-          <RefineModal opened={opened} onClose={close} />
+          <RefineModal opened={opened} onClose={close} gameItems={gameItems} />
         </Group>
       </div>
     </>

--- a/src/features/management/types/index.ts
+++ b/src/features/management/types/index.ts
@@ -61,3 +61,7 @@ export type GameListsType = {
   gameItems: GameCard[];
   isLoading: boolean;
 };
+
+export type AllGame = {
+  gameItems: GameCard[];
+};

--- a/src/features/management/utils/index.ts
+++ b/src/features/management/utils/index.ts
@@ -10,3 +10,18 @@ export const sortGamesByRating = (
     return ascending ? ratingA - ratingB : ratingB - ratingA;
   });
 };
+
+export const extractUniqueGenresAndPlatforms = (games: GameCard[]) => {
+  const genres: Set<string> = new Set();
+  const platforms: Set<string> = new Set();
+
+  games.forEach((game) => {
+    game.genres?.forEach((genre) => genres.add(genre.name));
+    game.platforms?.forEach((platform) => platforms.add(platform.name));
+  });
+
+  return {
+    genres: Array.from(genres),
+    platforms: Array.from(platforms),
+  };
+};


### PR DESCRIPTION
# 概要
- 全てのゲームデータの情報から、genreとplatformを抜き取り、RefineModalのボタンで表示できるようにする。
- RefineModalでgenreとplatformのボタンを押すと、GameStatusSelecterのゲームが絞り込みができるように設定。

# issue
Close #32 
