### PR TITLE
refactor: 不正アクセスの対処コードを再び追加

### DIFF
--- a/src/routes/RouteAuthGuard.tsx
+++ b/src/routes/RouteAuthGuard.tsx
@@ -1,7 +1,7 @@
 import { Container, Loader } from "@mantine/core";
 import { loginUserAtom } from "atoms/auth/loginUser";
 import { useAtomValue } from "jotai";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Navigate, useParams } from "react-router-dom";
 
 type RouteAuthGuardProps = {
@@ -17,24 +17,24 @@ export const RouteAuthGuard = ({
 }: RouteAuthGuardProps) => {
   const currentUser = useAtomValue(loginUserAtom);
   const { tab } = useParams();
-  // const [shouldRedirect, setShouldRedirect] = useState(false);
+  const [shouldRedirect, setShouldRedirect] = useState(false);
 
-  // useEffect(() => {
-  //   let timer: ReturnType<typeof setTimeout>;
-  //   if (!currentUser.authChecked) {
-  //     timer = setTimeout(() => {
-  //       setShouldRedirect(true); // ステートを更新
-  //     }, 10000);
-  //   }
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (!currentUser.authChecked) {
+      timer = setTimeout(() => {
+        setShouldRedirect(true); // ステートを更新
+      }, 3000);
+    }
 
-  //   return () => {
-  //     clearTimeout(timer);
-  //   };
-  // }, [currentUser.authChecked]);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [currentUser.authChecked]);
 
-  // if (shouldRedirect) {
-  //   return <Navigate to="/" replace={true} />;
-  // }
+  if (shouldRedirect) {
+    return <Navigate to="/" replace={true} />;
+  }
 
   if (validTabs && tab && !validTabs.includes(tab)) {
     return <Navigate to="/management/unplaying" replace />;


### PR DESCRIPTION
# 概要
自分のパソコンだけ、Google認証が遅い状況で開発するため、わざと外していた。高速で認証できるようになったので再び取り付ける。